### PR TITLE
fix(SLP send): using alternative SLP send function

### DIFF
--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -176,11 +176,21 @@ class Tokens {
       })
 
       // Add the SLP OP_RETURN to the transaction.
-      const slpSendObj = _this.bchjs.SLP.TokenType1.generateSendOpReturn(
+      // Uses slp-mdm
+      // const slpSendObj = _this.bchjs.SLP.TokenType1.generateSendOpReturn(
+      //   tokenUtxos,
+      //   output.qty
+      // )
+      // const slpData = slpSendObj.script
+      // transactionBuilder.addOutput(slpData, 0)
+
+      // Add the SLP OP_RETURN to the transaction.
+      // Uses web-friendly version.
+      const slpSendObj = _this.bchjs.SLP.TokenType1.generateSendOpReturnWeb(
         tokenUtxos,
         output.qty
       )
-      const slpData = slpSendObj.script
+      const slpData = _this.bchjs.Script.encode2(slpSendObj.script)
       transactionBuilder.addOutput(slpData, 0)
 
       // Send dust transaction representing tokens being sent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,9 +267,9 @@
       }
     },
     "@chris.troutner/bch-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@chris.troutner/bch-js/-/bch-js-3.3.0.tgz",
-      "integrity": "sha512-MWEWfmymURHShV8gihX/vewjE66g0r3uJw5/ws0e/UBQLxW/G0VKNvkoe0x6aNMv4qnWuEeTlAedxFy4giTf0g==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@chris.troutner/bch-js/-/bch-js-3.3.3.tgz",
+      "integrity": "sha512-P5bSJPglZSigolL2UAmJ+BgFb641SjrlUmBYetDBcunCKSZQHJ1Z5ihKvcJJBNjSBnrOAXRQtKGHTzLHKFaIRw==",
       "requires": {
         "@uppy/core": "^1.10.4",
         "@uppy/tus": "^1.5.12",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "repository": "Permissionless-Software-Foundation/minimal-slp-wallet",
   "dependencies": {
-    "@chris.troutner/bch-js": "3.3.0",
+    "@chris.troutner/bch-js": "3.3.3",
     "apidoc": "^0.23.0",
     "bch-donation": "^1.1.0",
     "crypto-js": "^4.0.0"


### PR DESCRIPTION
Replaces the SLP OP_RETURN generation function from bch-js. Was previously using slp-mdm, but now uses the older version that is *hopefully* web friendly.